### PR TITLE
Use gradle node configuration for fetching expoConstantsDir

### DIFF
--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -10,10 +10,10 @@ void runBefore(String dependentTaskName, Task task) {
   }
 }
 
-def expoConstantsDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-constants/package.json')));"].execute([], projectDir).text.trim()
-
 def config = project.hasProperty("react") ? project.react : [];
 def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
+
+def expoConstantsDir = [*nodeExecutableAndArgs, "-e", "console.log(require('path').dirname(require.resolve('expo-constants/package.json')));"].execute([], projectDir).text.trim()
 
 afterEvaluate {
   def projectRoot = file("../../")


### PR DESCRIPTION
Currently global node command is used for fetching expoConstantsDir, even if you overwrite node command using react.nodeExecutableAndArgs

# Why

I`m using [asdf](https://asdf-vm.com/#/) tool to manage multiple nodejs version.

# How

I can change node using `project.ext.react.nodeExecutableAndArgs` but script is still using default node for building expoConstantsDir

# Test Plan

Change node command using nodeExecutableAndArgs config.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.io and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).